### PR TITLE
Make error response to the web connector configurable

### DIFF
--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -52,4 +52,8 @@ QBWC.configure do |c|
   # Some log lines contain sensitive information
   # (default false on production, true otherwise)
   # c.log_requests_and_responses = false
+
+  # If a Ruby exception occurs during the session, its message is returned and displayed in the Web Connector window.
+  # Set this to a custom string to replace the exception's message with.
+  # c.error_message = nil
 end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -70,6 +70,10 @@ module QBWC
   mattr_accessor :log_requests_and_responses
   @@log_requests_and_responses = Rails.env == 'production' ? false : true
 
+  # Return a custom error message to the web connector instead of the exception's
+  mattr_accessor :error_message
+  @@error_message = nil
+
   class << self
 
     def storage_module

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -89,7 +89,7 @@ class QBWC::Session
       self.next_request # search next request
 
     rescue => e
-      self.error = e.message
+      self.error = QBWC.error_message || e.message
       QBWC.logger.warn "An error occured in QBWC::Session: #{e.message}"
       QBWC.logger.warn e.backtrace.join("\n")
     end


### PR DESCRIPTION
By default it dumps the message from whatever exception occurred
which is nice for debugging, but not so great for externally-facing
apps