### PR TITLE
Add user callback to operate on results from QB initial request

### DIFF
--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -56,4 +56,10 @@ QBWC.configure do |c|
   # If a Ruby exception occurs during the session, its message is returned and displayed in the Web Connector window.
   # Set this to a custom string to replace the exception's message with.
   # c.error_message = nil
+
+  # At the beginning of a session QuickBooks sends initial data including the response of a Host, Company, and Preferences query request, the active company file path, and QuickBooks country and version.
+  # This proc allows the user of the library to take advantage of that data
+  # c.received_initial_request = Proc.new { |session, hcp_response, company_file_name, country, major_vers, minor_vers|
+  #   Rails.logger.info("Company file for user #{session.user}" is: #{company_file_name}")
+  # }
 end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -74,6 +74,10 @@ module QBWC
   mattr_accessor :error_message
   @@error_message = nil
 
+  # Perform actions on the initial data sent by QB on each session start
+  mattr_accessor :received_initial_request
+  @@received_initial_request = nil
+
   class << self
 
     def storage_module

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -33,7 +33,7 @@ module QBWC
                     :response_tag => "#{wash_out_xml_namespace}authenticateResponse"
 
         soap_action 'sendRequestXML', :to => :send_request,
-                    :args   => {:ticket => :string, :strHCPResponse => :string, :strCompanyFilename => :string, :qbXMLCountry => :string, :qbXMLMajorVers => :string, :qbXMLMinorVers => :string},
+                    :args   => {:ticket => :string, :strHCPResponse => :string, :strCompanyFileName => :string, :qbXMLCountry => :string, :qbXMLMajorVers => :string, :qbXMLMinorVers => :string},
                     :return => {'tns:sendRequestXMLResult' => :string},
                     :response_tag => "#{wash_out_xml_namespace}sendRequestXMLResponse"
 
@@ -131,6 +131,11 @@ QWC
     end
 
     def send_request
+      if params[:strHCPResponse].present?
+        @session.received_initial_request(
+          *params.values_at(*%i(strHCPResponse strCompanyFileName qbXMLCountry qbXMLMajorVers qbXMLMinorVers))
+        )
+      end
       request = @session.request_to_send
       render :soap => {'tns:sendRequestXMLResult' => request}
     end


### PR DESCRIPTION
At the beginning of a session, QuickBooks sends the complete result
of a CompanyQuery, HostQuery, and PreferencesQuery, as well as
the currently connected company file path, country, and QuickBooks
major/minor version numbers.

This callback can be used to, for example, log/store the company file
and version information.

Shares QBXML parsing and exception handling with `response=`