### PR TITLE
Add callback to respond to connection errors

### DIFF
--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -62,4 +62,12 @@ QBWC.configure do |c|
   # c.received_initial_request = Proc.new { |session, hcp_response, company_file_name, country, major_vers, minor_vers|
   #   Rails.logger.info("Company file for user #{session.user}" is: #{company_file_name}")
   # }
+
+  # Respond to connection errors
+  # Return a new company file path to try or nil to let the session fail
+  # Exceptions in user code are caught and treated as a nil response
+  # c.on_connection_error = Proc.new { |hresult, message|
+  #   # try again with any company file
+  #   '' if hresult == '0x80040408'
+  # }
 end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -78,6 +78,10 @@ module QBWC
   mattr_accessor :received_initial_request
   @@received_initial_request = nil
 
+  # Respond to connection errors with a proc
+  mattr_accessor :on_connection_error
+  @@on_connection_error = nil
+
   class << self
 
     def storage_module

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -157,9 +157,17 @@ QWC
     end
 
     def connection_error
-      @session.destroy
-      logger.warn "#{params[:hresult]}: #{params[:message]}"
-      render :soap => {'tns:connectionErrorResult' => 'done'}
+      QBWC.logger.warn "#{params[:hresult]}: #{params[:message]}"
+      if QBWC.on_connection_error
+        begin
+          result = QBWC.on_connection_error.call(params[:hresult], params[:message])
+        rescue => e
+          QBWC.logger.warn "An error occured in QBWC::Session: #{e.message}"
+          QBWC.logger.warn e.backtrace.join("\n")
+        end
+      end
+      @session.destroy unless result
+      render :soap => {'tns:connectionErrorResult' => result || 'done'}
     end
 
     def get_last_error


### PR DESCRIPTION
Some results of this callback will change the course of the
session. Returning '' or a different company file path will
allow QBWC to reattempt the connection using any file or the
given file respectively.
Returning nil will simply continue closing the connection.