### PR TITLE
Add "serialization version" number to config for better backwards compatibility

### DIFF
--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -27,6 +27,11 @@ QBWC.configure do |c|
 
   # QBXML version to use. Check the "Implementation" column in the QuickBooks Onscreen Reference to see which fields are supported in which versions. Newer versions of QuickBooks are backwards compatible with older QBXML versions.
   c.min_version = "7.0"
+
+  # Version supported for serializing, as opposed to the version supported for parsing (min_version)
+  # your application writes QBXML conformant to this version or higher, but accepts QBXML conformant up to the min version above
+  # a serialization_version of nil or equal to the min_version is identical to the previous behavior
+  c.serialization_version = "7.0"
   
   # Quickbooks type (either :qb or :qbpos).
   c.api = :qb

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -30,6 +30,10 @@ module QBWC
   mattr_accessor :min_version
   @@min_version = "3.0"
 
+  # QBXML version to use for serializing (equal to min_version if nil). Check the "Implementation" column in the QuickBooks Onscreen Reference to see which fields are supported in which versions. Newer versions of QuickBooks are backwards compatible with older QBXML versions.
+  mattr_accessor :serialization_version
+  @@serialization_version = nil
+
   # Quickbooks type (either :qb or :qbpos).
   mattr_reader :api
   @@api = :qb
@@ -134,6 +138,10 @@ module QBWC
 
     def parser
       @@parser ||= Qbxml.new(api, min_version)
+    end
+
+    def write_parser
+      @@write_parser ||= Qbxml.new(api, serialization_version || min_version)
     end
 
     # Allow configuration overrides

--- a/lib/qbwc/request.rb
+++ b/lib/qbwc/request.rb
@@ -9,7 +9,7 @@ class QBWC::Request
     case
     when request.is_a?(Hash)
       request = self.class.wrap_request(request)
-      @request = QBWC.parser.to_qbxml(request, {:validate => true})
+      @request = QBWC.write_parser.to_qbxml(request, {:validate => true})
     when request.is_a?(String)
       @request = request
     else
@@ -18,7 +18,7 @@ class QBWC::Request
   end
 
   def to_qbxml
-    QBWC.parser.to_qbxml(request)
+    QBWC.write_parser.to_qbxml(request)
   end
 
   def to_hash


### PR DESCRIPTION


Request QBXML is generated according to this version of the spec
while response QBXML is parsed according to min_version.

The reason for supporting this is nuanced. Newer versions of QBXML
are backwards compatible with older QBXML versions, meaning that
newer versions of QuickBooks can parse QBXML generated with an older
version number, and a QBXML.rb parser initialized under a newer
version can parse older versions of QBXML, but the inverse is of
course not true. Newer versions of QuickBooks will gleefully
respond to an older-spec QBXML request with elements from a newer
QBXML version, so having the version sent equal to the version
parsed is not a solution for compatibility with anything more than
a single version.

Ideally to cast the widest net, the version number used for
generating will be as low as possible while the version number
accepted for parsing as high as possible.

This commit  makes the supported version effectively a range from
serialization_version to min_version.