### PR TITLE
Get pending job list from the session during authentication

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -119,7 +119,7 @@ QWC
         ticket = QBWC.storage_module::Session.new(username, company_file_path).ticket
         session = get_session(ticket)
 
-        if !QBWC.pending_jobs(company_file_path, session).present?
+        if !session.pending_jobs.any?
           QBWC.logger.info "Authentication of user '#{username}' succeeded, but no jobs pending for '#{company_file_path}'."
           company_file_path = AUTHENTICATE_NO_WORK
         else

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -109,6 +109,10 @@ class QBWC::Session
     @@session = nil
   end
 
+  def pending_jobs
+    @pending_jobs ||= QBWC.pending_jobs(@company, self)
+  end
+
   protected
 
   attr_accessor :current_job, :iterator_id
@@ -120,10 +124,6 @@ class QBWC::Session
     self.current_job = pending_jobs.first
     self.current_job.reset if reset_job && self.current_job
     return self.current_job
-  end
-
-  def pending_jobs
-    @pending_jobs ||= QBWC.pending_jobs(@company, self)
   end
 
   def complete_with_success


### PR DESCRIPTION
The result is that should_run? will only be called once per job.
Previously the auth method reconstructed the pending jobs list
from scratch immediately after it was built and stored in the session,
making it possible for conditionally run jobs to produce a different
result, a situation which QBWC is not equipped to handle