### PR TITLE
Support per-session/user qbxml serializers

### DIFF
--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -114,7 +114,7 @@ class QBWC::Job
     return nil if ri.nil? || reqs.nil? || ri >= reqs.length
     nr = reqs[ri]
     QBWC.logger.info("Next request is '#{nr}'.") if QBWC.log_requests_and_responses
-    return QBWC::Request.new(nr) if nr
+    return QBWC::Request.new(nr, session) if nr
   end
   alias :next :next_request  # Deprecated method name 'next'
 

--- a/lib/qbwc/request.rb
+++ b/lib/qbwc/request.rb
@@ -2,14 +2,14 @@ class QBWC::Request
 
   attr_reader   :request, :response_proc
 
-  def initialize(request)
+  def initialize(request, session)
     #Handle Cases for a request passed in as a Hash or String
     #If it's a hash verify that it is properly wrapped with qbxml_msg_rq and xml_attributes for on_error events
     #Allow strings of QBXML to be passed in directly. 
     case
     when request.is_a?(Hash)
       request = self.class.wrap_request(request)
-      @request = QBWC.write_parser.to_qbxml(request, {:validate => true})
+      @request = QBWC.write_parser(session).to_qbxml(request, {:validate => true})
     when request.is_a?(String)
       @request = request
     else

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -74,7 +74,7 @@ class QBWC::Session
       request = request.to_hash
       request.delete('xml_attributes')
       request.values.first['xml_attributes'] = {'iterator' => 'Continue', 'iteratorID' => self.iterator_id}
-      request = QBWC::Request.new(request)
+      request = QBWC::Request.new(request, self)
     end 
     request
   end


### PR DESCRIPTION
Extends serialization_version to accept a proc which, given the
session object, may return an appropriate version