### PR TITLE
Provide raw qbxml response to workers in backwards-compatible way

### DIFF
--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -27,7 +27,7 @@ class QBWC::Job
     request_list = requests(session)
     completed_request = request_list[request_index(session)] if request_list
     advance_next_request(session) if advance
-    worker.handle_response(response, session, self, completed_request, data)
+    worker.handle_qbxml_response(qbxml_response, response, session, self, completed_request, data)
   end
 
   def advance_next_request(session)

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -12,5 +12,9 @@ module QBWC
     def handle_response(response, session, job, request, data)
     end
 
+    def handle_qbxml_response(qbxml_response, response, session, job, request, data)
+      handle_response(response, session, job, request, data)
+    end
+
   end
 end


### PR DESCRIPTION
Adds handle_response_with_qbxml method to QBWC::Worker which may be
implemented in place of handle_response and receives the XML
returned from QuickBooks as a parameter