### PR TITLE
Add customizable response exception handling

### DIFF
--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -75,9 +75,12 @@ module QBWC
   mattr_accessor :log_requests_and_responses
   @@log_requests_and_responses = Rails.env == 'production' ? false : true
 
-  # Return a custom error message to the web connector instead of the exception's
-  mattr_accessor :error_message
-  @@error_message = nil
+  # Handler for any exceptions raised during request processing (including execution of qbwc_jobs)
+  # Result must be a string; this is the error text which will be displayed on the web connector itself.
+  # By default this is the exception message.
+  # Takes the exception object and the QBXML response data currently being processed.
+  mattr_accessor :handle_exception
+  @@handle_exception = Proc.new { |e, qbxml_response| e.message }
 
   # Perform actions on the initial data sent by QB on each session start
   mattr_accessor :received_initial_request

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -167,7 +167,7 @@ class QBWC::Session
       end
       yield response
     rescue => e
-      self.error = QBWC.error_message || e.message
+      self.error = QBWC.handle_exception(e, qbxml_response)
       QBWC.logger.warn "An error occured in QBWC::Session: #{e.message}"
       QBWC.logger.warn e.backtrace.join("\n")
     end


### PR DESCRIPTION
Callers can define a handle_exception method which does something
with exception objects and the corresponding qbxml_response,
and returns an error message to display back to the user.
By default, this is just the exception message.

Supercedes the 'error_message' attribute.